### PR TITLE
Add certification breakdown to line items table

### DIFF
--- a/pages/order/step-3.js
+++ b/pages/order/step-3.js
@@ -1078,6 +1078,7 @@ export default function Step3() {
       if (updatedItems.length === 0) {
         setLineItems(updatedItems);
         setPricing({ subtotal: 0, estimatedTax: 0, total: 0 });
+        setDeliveryEstimates(null);
         setError('All documents were removed. A human specialist will follow up with you.');
         await triggerHitlReview(quoteId);
         setShowHITL(true);
@@ -1090,6 +1091,7 @@ export default function Step3() {
 
       if (newTotals.total <= 0) {
         setPricing(newTotals);
+        setDeliveryEstimates(null);
         setError('Quote total dropped to $0. Our human team will finish this quote.');
         await triggerHitlReview(quoteId);
         setShowHITL(true);
@@ -1098,6 +1100,7 @@ export default function Step3() {
 
       if (newTotals.subtotal < minimumOrder) {
         setPricing(newTotals);
+        setDeliveryEstimates(null);
         if (typeof window !== 'undefined') {
           window.alert(`Removing this document brings your order below the ${formatCurrency(minimumOrder)} minimum. Requesting human review.`);
         }


### PR DESCRIPTION
## Purpose

The user requested a complete line items table implementation with detailed certification breakdown functionality. They wanted to display pricing breakdowns showing both translation costs and certification costs separately, with improved mobile responsiveness and better user experience when removing items.

## Code changes

- **Added `safeNumber()` utility function** for robust number parsing with fallback defaults
- **Enhanced `normalizeLineItems()`** to handle both camelCase and snake_case property formats and include certification type names
- **Improved `calculateTotals()`** with safer number handling and null checking
- **Refactored `saveQuoteResults()`** to accept cleaner parameters and build comprehensive results payload with pricing breakdown
- **Completely redesigned `LineItemsTable` component**:
  - Added desktop table with "Price Breakdown" column showing translation + certification costs
  - Implemented responsive mobile cards with detailed cost breakdowns
  - Enhanced remove functionality with confirmation dialogs showing cost impact
  - Added certification type display and better visual hierarchy
- **Updated database query** to include `certification_type_name` field
- **Improved error handling** and user feedback throughout the removal process

The changes provide a comprehensive pricing breakdown view that clearly separates translation and certification costs while maintaining data consistency across different property naming conventions.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 7`

🔗 [Edit in Builder.io](https://builder.io/app/projects/89e37d52885f4fd0b72eb3f3b05ca6e4/orbit-hub)

👀 [Preview Link](https://89e37d52885f4fd0b72eb3f3b05ca6e4-orbit-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>89e37d52885f4fd0b72eb3f3b05ca6e4</projectId>-->
<!--<branchName>orbit-hub</branchName>-->