### PR TITLE
Fix auth verify page build error by converting to SSR

### DIFF
--- a/pages/auth/verify.js
+++ b/pages/auth/verify.js
@@ -11,28 +11,26 @@ function setSessionCookie(res, token) {
 export default function VerifyPage({ error }) {
   if (error) {
     return (
-      <html>
-        <body style={{ fontFamily: 'system-ui, -apple-system', padding: 40 }}>
-          <div style={{ maxWidth: 560, margin: '0 auto' }}>
-            <h1 style={{ margin: '0 0 12px', color: '#111' }}>Login Error</h1>
-            <p style={{ color: '#444', margin: '0 0 18px' }}>{error}</p>
-            <a
-              href="/login"
-              style={{
-                display: 'inline-block',
-                background: '#00B8D4',
-                color: '#fff',
-                textDecoration: 'none',
-                padding: '10px 16px',
-                borderRadius: 8,
-                fontWeight: 700,
-              }}
-            >
-              Go to Login
-            </a>
-          </div>
-        </body>
-      </html>
+      <div style={{ fontFamily: 'system-ui, -apple-system', padding: 40 }}>
+        <div style={{ maxWidth: 560, margin: '0 auto' }}>
+          <h1 style={{ margin: '0 0 12px', color: '#111' }}>Login Error</h1>
+          <p style={{ color: '#444', margin: '0 0 18px' }}>{error}</p>
+          <a
+            href="/login"
+            style={{
+              display: 'inline-block',
+              background: '#00B8D4',
+              color: '#fff',
+              textDecoration: 'none',
+              padding: '10px 16px',
+              borderRadius: 8,
+              fontWeight: 700,
+            }}
+          >
+            Go to Login
+          </a>
+        </div>
+      </div>
     );
   }
   return null;

--- a/pages/auth/verify.js
+++ b/pages/auth/verify.js
@@ -1,18 +1,50 @@
-import { getSupabaseServerClient } from '../../lib/supabaseServer';
+import React from 'react';
 import crypto from 'crypto';
+import { getSupabaseServerClient } from '../../lib/supabaseServer';
 
-function setSessionCookie(res, token){
+function setSessionCookie(res, token) {
   const isProd = process.env.NODE_ENV === 'production';
-  const cookie = `session_token=${token}; Max-Age=${30*24*60*60}; Path=/; HttpOnly; SameSite=Lax${isProd?'; Secure':''}`;
+  const cookie = `session_token=${token}; Max-Age=${30 * 24 * 60 * 60}; Path=/; HttpOnly; SameSite=Lax${isProd ? '; Secure' : ''}`;
   res.setHeader('Set-Cookie', cookie);
 }
 
-export default async function handler(req, res){
+export default function VerifyPage({ error }) {
+  if (error) {
+    return (
+      <html>
+        <body style={{ fontFamily: 'system-ui, -apple-system', padding: 40 }}>
+          <div style={{ maxWidth: 560, margin: '0 auto' }}>
+            <h1 style={{ margin: '0 0 12px', color: '#111' }}>Login Error</h1>
+            <p style={{ color: '#444', margin: '0 0 18px' }}>{error}</p>
+            <a
+              href="/login"
+              style={{
+                display: 'inline-block',
+                background: '#00B8D4',
+                color: '#fff',
+                textDecoration: 'none',
+                padding: '10px 16px',
+                borderRadius: 8,
+                fontWeight: 700,
+              }}
+            >
+              Go to Login
+            </a>
+          </div>
+        </body>
+      </html>
+    );
+  }
+  return null;
+}
+
+export async function getServerSideProps({ req, res, query }) {
   try {
-    const token = String(req.query.token || '');
+    const token = String(query.token || '');
     if (!token || token.length < 10) {
-      return res.status(400).send(renderError('Invalid or expired link'));
+      return { props: { error: 'Invalid or expired link' } };
     }
+
     const supabase = getSupabaseServerClient();
 
     const { data: link } = await supabase
@@ -21,54 +53,84 @@ export default async function handler(req, res){
       .eq('token', token)
       .maybeSingle();
 
-    if (!link) return res.status(400).send(renderError('Invalid or expired link'));
-    if (link.used_at) return res.status(400).send(renderError('Invalid or expired link'));
-    if (new Date(link.expires_at).getTime() <= Date.now()) return res.status(400).send(renderError('Invalid or expired link'));
+    if (!link) return { props: { error: 'Invalid or expired link' } };
+    if (link.used_at) return { props: { error: 'Invalid or expired link' } };
+    if (new Date(link.expires_at).getTime() <= Date.now()) return { props: { error: 'Invalid or expired link' } };
 
     const userType = link.user_type === 'admin' ? 'admin' : 'customer';
 
     let user = null;
     if (userType === 'admin') {
-      const { data } = await supabase.from('admin_users').select('id, email, first_name, last_name').eq('id', link.user_id).maybeSingle();
+      const { data } = await supabase
+        .from('admin_users')
+        .select('id, email, first_name, last_name')
+        .eq('id', link.user_id)
+        .maybeSingle();
       user = data;
     } else {
-      const { data } = await supabase.from('users').select('id, email, first_name, last_name').eq('id', link.user_id).maybeSingle();
+      const { data } = await supabase
+        .from('users')
+        .select('id, email, first_name, last_name')
+        .eq('id', link.user_id)
+        .maybeSingle();
       user = data;
     }
-    if (!user) return res.status(400).send(renderError('Invalid or expired link'));
+
+    if (!user) return { props: { error: 'Invalid or expired link' } };
 
     const nowIso = new Date().toISOString();
-    const ip = (req.headers['x-forwarded-for'] || req.socket.remoteAddress || '').toString().split(',')[0].trim();
+    const ip = (req.headers['x-forwarded-for'] || req.socket.remoteAddress || '')
+      .toString()
+      .split(',')[0]
+      .trim();
     const userAgent = req.headers['user-agent'] || '';
 
-    await supabase.from('magic_links').update({ used_at: nowIso, used_ip: ip || null, used_user_agent: userAgent || null }).eq('id', link.id);
+    await supabase
+      .from('magic_links')
+      .update({ used_at: nowIso, used_ip: ip || null, used_user_agent: userAgent || null })
+      .eq('id', link.id);
 
     const sessionToken = crypto.randomBytes(32).toString('hex');
-    const expiresAt = new Date(Date.now() + 30*24*60*60*1000).toISOString();
-    await supabase.from('user_sessions').insert([{ user_id: user.id, user_type: userType, session_token: sessionToken, expires_at: expiresAt, ip: ip || null, user_agent: userAgent || null }]);
+    const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+
+    await supabase.from('user_sessions').insert([
+      {
+        user_id: user.id,
+        user_type: userType,
+        session_token: sessionToken,
+        expires_at: expiresAt,
+        ip: ip || null,
+        user_agent: userAgent || null,
+      },
+    ]);
 
     if (userType === 'admin') {
-      await supabase.from('admin_users').update({ last_login_at: nowIso, email_verified: true, updated_at: nowIso }).eq('id', user.id);
+      await supabase
+        .from('admin_users')
+        .update({ last_login_at: nowIso, email_verified: true, updated_at: nowIso })
+        .eq('id', user.id);
     } else {
-      await supabase.from('users').update({ last_login_at: nowIso, email_verified: true, email_verified_at: nowIso, updated_at: nowIso }).eq('id', user.id);
+      await supabase
+        .from('users')
+        .update({ last_login_at: nowIso, email_verified: true, email_verified_at: nowIso, updated_at: nowIso })
+        .eq('id', user.id);
     }
 
     setSessionCookie(res, sessionToken);
 
-    const redirectUrl = (link.metadata && link.metadata.redirect_url) ? link.metadata.redirect_url : (userType === 'admin' ? '/admin/dashboard' : '/dashboard');
-    res.writeHead(302, { Location: redirectUrl });
-    return res.end();
-  } catch (err) {
-    return res.status(500).send(renderError('Unexpected error'));
-  }
-}
+    const redirectUrl = link.metadata && link.metadata.redirect_url
+      ? link.metadata.redirect_url
+      : userType === 'admin'
+      ? '/admin/dashboard'
+      : '/dashboard';
 
-function renderError(message){
-  return `<!DOCTYPE html><html><body style="font-family: system-ui, -apple-system; padding:40px;">
-  <div style="max-width:560px;margin:0 auto;">
-    <h1 style="margin:0 0 12px;color:#111;">Login Error</h1>
-    <p style="color:#444;margin:0 0 18px;">${message}</p>
-    <a href="/login" style="display:inline-block;background:#00B8D4;color:#fff;text-decoration:none;padding:10px 16px;border-radius:8px;font-weight:700;">Go to Login</a>
-  </div>
-</body></html>`;
+    return {
+      redirect: {
+        destination: redirectUrl,
+        permanent: false,
+      },
+    };
+  } catch (err) {
+    return { props: { error: 'Unexpected error' } };
+  }
 }


### PR DESCRIPTION
## Purpose
Fix Netlify build failures caused by a `TypeError: t.status is not a function` error on the `/auth/verify` page. The error was occurring during static page generation due to improper handling of server-side operations in an API route context.

## Code changes
- **Converted API route to Next.js page**: Transformed `/pages/auth/verify.js` from an API route handler to a proper Next.js page component with `getServerSideProps`
- **Replaced res.status() calls**: Removed all `res.status().send()` calls that were causing the build error and replaced them with proper Next.js redirect/props patterns
- **Added React component**: Created a `VerifyPage` component to handle error display with inline styling
- **Improved error handling**: Converted server-side errors to props-based error handling for better SSR compatibility
- **Code formatting**: Applied consistent formatting and spacing throughout the file
- **Added proper imports**: Added React import and reorganized import statements

The changes ensure the verification flow works correctly during both build time and runtime while maintaining the same functionality for magic link authentication.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 19`

🔗 [Edit in Builder.io](https://builder.io/app/projects/89e37d52885f4fd0b72eb3f3b05ca6e4/curry-space)

👀 [Preview Link](https://89e37d52885f4fd0b72eb3f3b05ca6e4-curry-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>89e37d52885f4fd0b72eb3f3b05ca6e4</projectId>-->
<!--<branchName>curry-space</branchName>-->