### PR TITLE
Fix 500 errors in link-user API with better error handling

### DIFF
--- a/lib/supabaseServer.js
+++ b/lib/supabaseServer.js
@@ -1,5 +1,13 @@
 import { createClient } from '@supabase/supabase-js';
 
+export function hasServiceRoleKey() {
+  return Boolean(
+    process.env.SUPABASE_SERVICE_ROLE_KEY ||
+      process.env.SUPABASE_SERVICE_KEY ||
+      process.env.SUPABASE_SECRET_KEY
+  );
+}
+
 function resolveKey() {
   const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
     || process.env.SUPABASE_SERVICE_KEY


### PR DESCRIPTION
## Purpose

User was experiencing 500 Internal Server Errors when accessing step 2 of the quote process. The `/api/quotes/link-user` endpoint was failing with "Unexpected error" messages, preventing users from completing the quote linking process. This fix aims to resolve the server errors and provide better error visibility for debugging.

## Code changes

- **Added service role key validation**: New `hasServiceRoleKey()` function checks for required Supabase environment variables and returns early 500 error if missing
- **Enhanced error handling**: Added proper error checking for all Supabase database operations (select, update, insert, RPC calls)
- **Improved error reporting**: Replace generic "Unexpected error" with actual error messages and added console logging for debugging
- **Comprehensive error propagation**: All database operations now properly throw errors instead of silently failing

The changes ensure that database errors are properly caught and reported, making it easier to identify the root cause of 500 errors while preventing silent failures in the quote linking process.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 21`

🔗 [Edit in Builder.io](https://builder.io/app/projects/89e37d52885f4fd0b72eb3f3b05ca6e4/nova-world)

👀 [Preview Link](https://89e37d52885f4fd0b72eb3f3b05ca6e4-nova-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>89e37d52885f4fd0b72eb3f3b05ca6e4</projectId>-->
<!--<branchName>nova-world</branchName>-->