### PR TITLE
Add Resume Quote functionality for draft quotes

### DIFF
--- a/pages/dashboard/quotes/[id].js
+++ b/pages/dashboard/quotes/[id].js
@@ -156,6 +156,37 @@ export default function QuoteDetailPage() {
         </div>
 
         <aside className="space-y-6">
+          {quote.quote_state === 'draft' && (
+            <section className="bg-white rounded-lg border border-gray-200 p-4">
+              <h2 className="font-semibold text-gray-900 mb-3">Actions</h2>
+              <Link href={`/order/step-${(quote.last_completed_step || 1) + 1}?quote_id=${quote.id}`}>
+                <button className="w-full bg-cyan-500 hover:bg-cyan-600 text-white py-2 rounded-lg font-semibold">Resume Quote</button>
+              </Link>
+            </section>
+          )}
+
+          {quote.quote_state === 'draft' && (
+            <section className="bg-white rounded-lg border border-gray-200 p-4">
+              <h2 className="font-semibold text-gray-900 mb-3">Progress</h2>
+              <ol className="space-y-2">
+                {[1,2,3,4].map((step) => {
+                  const isCompleted = step <= (quote.last_completed_step || 1);
+                  const isNext = step === ((quote.last_completed_step || 1) + 1);
+                  return (
+                    <li key={step} className="flex items-center gap-2 text-sm">
+                      <span className={`flex items-center justify-center w-6 h-6 rounded-full text-white text-xs ${isCompleted ? 'bg-green-500' : isNext ? 'bg-cyan-500' : 'bg-gray-300'}`}>
+                        {isCompleted ? '✓' : step}
+                      </span>
+                      <span className={`${isCompleted ? 'text-gray-900' : isNext ? 'text-cyan-700' : 'text-gray-500'}`}>
+                        {step === 1 ? 'Upload Documents' : step === 2 ? 'Details' : step === 3 ? 'Shipping & Options' : 'Review Quote'}
+                      </span>
+                    </li>
+                  );
+                })}
+              </ol>
+            </section>
+          )}
+
           <section className="bg-white rounded-lg border border-gray-200 p-4">
             <h2 className="font-semibold text-gray-900 mb-3">Pricing</h2>
             {quote.quote_results?.pricing ? (

--- a/pages/dashboard/quotes/index.js
+++ b/pages/dashboard/quotes/index.js
@@ -131,6 +131,9 @@ export default function QuotesListPage() {
               </div>
               <div className="mt-4 flex gap-2">
                 <Link href={`/dashboard/quotes/${q.id}`} className="px-3 py-2 bg-gray-100 rounded-lg text-sm">View</Link>
+                {q.quote_state === 'draft' && (
+                  <Link href={`/order/step-${(q.last_completed_step || 1) + 1}?quote_id=${q.id}`} className="px-3 py-2 bg-cyan-500 text-white rounded-lg text-sm">Resume Quote</Link>
+                )}
                 {q.quote_state === 'expired' && (
                   <button onClick={() => handleRegenerate(q.id)} className="px-3 py-2 bg-yellow-100 text-yellow-800 rounded-lg text-sm">Regenerate</button>
                 )}


### PR DESCRIPTION
## Purpose

This PR implements the "Resume Quote" functionality for draft quotes as requested. The user needed to verify and implement the ability for users to continue their draft quotes from both the quotes list page and quote detail page, allowing seamless continuation of incomplete quote workflows.

## Code Changes

### Quote List Page (`/pages/dashboard/quotes/index.js`)
- Added "Resume Quote" button for draft quotes in the quote list
- Button links to the next incomplete step: `/order/step-${last_completed_step + 1}?quote_id=${quote.id}`
- Styled with cyan background to match design requirements

### Quote Detail Page (`/pages/dashboard/quotes/[id].js`)
- Added **Actions Card** section that displays for draft quotes only
- Includes prominent "Resume Quote" button with cyan styling and hover effects
- Added **Progress Card** section showing visual step progress for draft quotes
- Progress indicators show completed steps (green checkmarks), current step (cyan), and pending steps (gray)
- Step labels: "Upload Documents", "Details", "Shipping & Options", "Review Quote"

Both implementations include proper conditional rendering based on `quote_state === 'draft'` and handle the `last_completed_step` logic to direct users to the appropriate next step in the quote process.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 27`

🔗 [Edit in Builder.io](https://builder.io/app/projects/89e37d52885f4fd0b72eb3f3b05ca6e4/glow-world)

👀 [Preview Link](https://89e37d52885f4fd0b72eb3f3b05ca6e4-glow-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>89e37d52885f4fd0b72eb3f3b05ca6e4</projectId>-->
<!--<branchName>glow-world</branchName>-->