### PR TITLE
Fix admin dashboard layout with proper flex structure

### DIFF
--- a/components/admin/AdminHeader.jsx
+++ b/components/admin/AdminHeader.jsx
@@ -9,7 +9,7 @@ export default function AdminHeader({ admin, onToggleSidebar, collapsed }){
     }
   }
   return (
-    <header className="sticky top-0 z-30 h-16 border-b bg-white shadow-sm">
+    <header className="app-header sticky top-0 z-30 h-16 border-b bg-white shadow-sm">
       <div className="mx-auto flex h-full items-center justify-between px-4">
         <div className="flex items-center gap-3">
           <button className="p-2 -ml-2 rounded-md hover:bg-gray-100 lg:hidden" aria-label="Open sidebar" onClick={onToggleSidebar}>

--- a/components/admin/AdminLayout.jsx
+++ b/components/admin/AdminLayout.jsx
@@ -20,19 +20,22 @@ export default function AdminLayout({ children, title, initialAdmin, pendingCoun
   function closeSidebar(){ setSidebarOpen(false); }
 
   return (
-    <div className="min-h-screen bg-slate-50">
-      <AdminHeader admin={initialAdmin} onToggleSidebar={toggleSidebar} collapsed={collapsed} />
-      <div className="relative">
-        {sidebarOpen && (
-          <div className="fixed inset-0 z-30 bg-black/40 lg:hidden" onClick={closeSidebar} />
-        )}
-        <div className={`z-40 transition-transform ${sidebarOpen ? 'translate-x-0' : '-translate-x-full'} lg:translate-x-0`}>
-          <AdminSidebar collapsed={collapsed} pendingCounts={pendingCounts} onClose={closeSidebar} admin={initialAdmin} />
-        </div>
-      </div>
+    <div className="app-shell flex flex-row min-h-screen h-full overflow-hidden bg-slate-50">
+      {sidebarOpen && (
+        <div className="fixed inset-0 z-30 bg-black/40 lg:hidden" onClick={closeSidebar} />
+      )}
 
-      <main className={`pt-6 md:pl-16 lg:pl-60`}>
-        <div className="mx-auto max-w-7xl px-4">
+      <AdminSidebar
+        collapsed={collapsed}
+        pendingCounts={pendingCounts}
+        onClose={closeSidebar}
+        admin={initialAdmin}
+        sidebarOpen={sidebarOpen}
+      />
+
+      <main className="app-main ml-0 md:ml-16 lg:ml-60 flex-1 flex flex-col min-h-screen overflow-auto">
+        <AdminHeader admin={initialAdmin} onToggleSidebar={toggleSidebar} collapsed={collapsed} />
+        <div className="px-4 pt-6">
           {title && <h1 className="mb-4 text-2xl font-semibold text-gray-900">{title}</h1>}
           {children}
         </div>

--- a/components/admin/AdminSidebar.jsx
+++ b/components/admin/AdminSidebar.jsx
@@ -28,7 +28,7 @@ function Chevron({ open }){
   );
 }
 
-export default function AdminSidebar({ collapsed, pendingCounts = {} , onClose, admin }){
+export default function AdminSidebar({ collapsed, pendingCounts = {} , onClose, admin, sidebarOpen }){
   const router = useRouter();
   const path = router.asPath || router.pathname || '';
   const isActive = (href) => path === href || path.startsWith(href + '/');
@@ -37,9 +37,8 @@ export default function AdminSidebar({ collapsed, pendingCounts = {} , onClose, 
   const role = admin?.role || null;
 
   return (
-    <aside className={`fixed inset-y-0 left-0 z-40 bg-slate-900 transition-all lg:static lg:translate-x-0 ${collapsed ? 'w-16' : 'w-60'} ${collapsed ? '' : ''}`}>
-      <div className="h-16" />
-      <nav className="px-2">
+    <aside className={`app-sidebar fixed inset-y-0 left-0 z-40 bg-slate-900 transform transition-transform ${sidebarOpen ? 'translate-x-0' : '-translate-x-full'} lg:translate-x-0 ${collapsed ? 'w-16' : 'w-60'} h-screen overflow-y-auto`}>
+      <nav className="px-2 py-3">
         <SectionLabel collapsed={collapsed}>General</SectionLabel>
         <NavItem href="/admin/dashboard" label="Dashboard" collapsed={collapsed} active={isActive('/admin/dashboard')} badge={null} icon={
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="h-5 w-5"><path d="M3 12l9-9 9 9v8a1 1 0 01-1 1h-5v-6H9v6H4a1 1 0 01-1-1v-8z"/></svg>


### PR DESCRIPTION
## Purpose

Fix the admin dashboard layout to eliminate large empty white space in the main content area. The goal is to create a proper app-shell layout where the sidebar remains fixed and usable, the main content fills the available space correctly, and header & content scroll behavior works properly across desktop, tablet, and mobile devices.

## Code changes

- **AdminLayout.jsx**: Restructured the layout to use a flex-based app-shell pattern with `app-shell` class, moved header inside main content area, and updated responsive margin classes for proper sidebar spacing
- **AdminHeader.jsx**: Added `app-header` class for consistent styling and positioning within the new layout structure  
- **AdminSidebar.jsx**: Added `app-sidebar` class, improved responsive transform behavior with `sidebarOpen` prop, removed redundant header spacing, and enhanced mobile sidebar functionality

The changes implement a robust flex layout that ensures the main content area properly fills the available space while maintaining a fixed sidebar and proper responsive behavior.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 54`

🔗 [Edit in Builder.io](https://builder.io/app/projects/89e37d52885f4fd0b72eb3f3b05ca6e4/nova-sanctuary)

👀 [Preview Link](https://89e37d52885f4fd0b72eb3f3b05ca6e4-nova-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>89e37d52885f4fd0b72eb3f3b05ca6e4</projectId>-->
<!--<branchName>nova-sanctuary</branchName>-->