### PR TITLE
Fix import paths for apiAdmin and supabaseServer modules

### DIFF
--- a/pages/api/admin/quotes/index.js
+++ b/pages/api/admin/quotes/index.js
@@ -1,5 +1,5 @@
-import { withPermission } from '../../../../../lib/apiAdmin';
-import { getSupabaseServerClient } from '../../../../../lib/supabaseServer';
+import { withPermission } from '../../../../lib/apiAdmin';
+import { getSupabaseServerClient } from '../../../../lib/supabaseServer';
 
 function parseQuery(q){
   const page = Math.max(1, Number(q.page || 1));


### PR DESCRIPTION
## Purpose
Fix Netlify build failure caused by incorrect import paths for `apiAdmin` and `supabaseServer` modules. The build was failing because the modules could not be resolved due to incorrect relative path references.

## Code changes
- Updated import path for `withPermission` from `../../../../../lib/apiAdmin` to `../../../../lib/apiAdmin`
- Updated import path for `getSupabaseServerClient` from `../../../../../lib/supabaseServer` to `../../../../lib/supabaseServer`
- Corrected the relative path depth by removing one level (`../`) from both imports in `pages/api/admin/quotes/index.js`

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 66`

🔗 [Edit in Builder.io](https://builder.io/app/projects/89e37d52885f4fd0b72eb3f3b05ca6e4/pixel-oasis)

👀 [Preview Link](https://89e37d52885f4fd0b72eb3f3b05ca6e4-pixel-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>89e37d52885f4fd0b72eb3f3b05ca6e4</projectId>-->
<!--<branchName>pixel-oasis</branchName>-->