### PR TITLE
Add OCR analysis API endpoint with upsert functionality

### DIFF
--- a/pages/api/n8n/ocr-analysis.js
+++ b/pages/api/n8n/ocr-analysis.js
@@ -1,0 +1,80 @@
+import { withApiBreadcrumbs } from '../../../lib/sentry';
+import { getSupabaseServerClient } from '../../../lib/supabaseServer';
+
+function extractSecret(req) {
+  const headerSecret = req.headers['x-webhook-secret']
+    || req.headers['x-n8n-secret']
+    || req.headers['x-hook-secret'];
+  if (headerSecret) return Array.isArray(headerSecret) ? headerSecret[0] : headerSecret;
+  const authHeader = req.headers.authorization;
+  if (typeof authHeader === 'string' && authHeader.startsWith('Bearer ')) {
+    return authHeader.slice(7);
+  }
+  return null;
+}
+
+function normalizeRow(input) {
+  if (!input || typeof input !== 'object') return null;
+  const row = { ...input };
+  if (row.page_number != null) {
+    const n = Number(row.page_number);
+    if (!Number.isNaN(n)) row.page_number = n;
+  }
+  if (typeof row.filename === 'string') row.filename = row.filename.trim();
+  if (typeof row.quote_id === 'string') row.quote_id = row.quote_id.trim();
+  row.updated_at = new Date().toISOString();
+  return row;
+}
+
+async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  const sharedSecret = process.env.N8N_WEBHOOK_SECRET;
+  if (sharedSecret) {
+    const receivedSecret = extractSecret(req);
+    if (receivedSecret !== sharedSecret) {
+      return res.status(401).json({ error: 'Invalid webhook secret' });
+    }
+  }
+
+  const body = req.body;
+  let rows = [];
+  if (Array.isArray(body)) rows = body;
+  else if (body && typeof body === 'object') {
+    if (Array.isArray(body.rows)) rows = body.rows;
+    else rows = [body];
+  }
+
+  rows = rows.map(normalizeRow).filter(Boolean);
+
+  if (rows.length === 0) {
+    return res.status(400).json({ error: 'No rows provided' });
+  }
+
+  for (const r of rows) {
+    if (!r.quote_id || !r.filename || (r.page_number == null)) {
+      return res.status(400).json({ error: 'quote_id, filename, and page_number are required for each row' });
+    }
+  }
+
+  try {
+    const supabase = getSupabaseServerClient();
+    const { data, error } = await supabase
+      .from('ocr_analysis')
+      .upsert(rows, { onConflict: 'quote_id,filename,page_number', ignoreDuplicates: false, defaultToNull: false })
+      .select('quote_id, filename, page_number');
+
+    if (error) {
+      return res.status(500).json({ error: error.message || 'Upsert failed' });
+    }
+
+    return res.status(200).json({ ok: true, upserted: data || [] });
+  } catch (err) {
+    return res.status(500).json({ error: err.message || 'Unexpected error' });
+  }
+}
+
+export default withApiBreadcrumbs(handler);


### PR DESCRIPTION
## Purpose

Fix N8N workflow error caused by duplicate key violations when inserting OCR analysis data. The user encountered a constraint violation error (`ocr_analysis_pkey`) when trying to create rows with duplicate `(quote_id, filename, page_number)` combinations. The solution implements an upsert operation to handle existing records gracefully instead of failing on duplicates.

## Code changes

- **New API endpoint**: Created `/pages/api/n8n/ocr-analysis.js` to handle OCR analysis data operations
- **Upsert functionality**: Implemented Supabase upsert with conflict resolution on `quote_id, filename, page_number` composite key
- **Input validation**: Added validation for required fields and data normalization
- **Authentication**: Integrated webhook secret validation for N8N security
- **Error handling**: Comprehensive error responses for various failure scenarios
- **Data processing**: Support for both single row and batch operations with automatic data type conversion

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 67`

🔗 [Edit in Builder.io](https://builder.io/app/projects/89e37d52885f4fd0b72eb3f3b05ca6e4/vibe-sanctuary)

👀 [Preview Link](https://89e37d52885f4fd0b72eb3f3b05ca6e4-vibe-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>89e37d52885f4fd0b72eb3f3b05ca6e4</projectId>-->
<!--<branchName>vibe-sanctuary</branchName>-->