### PR TITLE
Add run_id support to quote totals calculation

### DIFF
--- a/lib/quoteTotals.js
+++ b/lib/quoteTotals.js
@@ -2,14 +2,40 @@ import { getSupabaseServerClient } from './supabaseServer';
 
 function round2(v){ return Math.round(Number(v||0) * 100) / 100; }
 
-export async function recalcAndUpsertUnifiedQuoteResults(quoteId){
+export async function recalcAndUpsertUnifiedQuoteResults(quoteId, runId){
   const supabase = getSupabaseServerClient();
 
+  // Determine effective run id if not provided: active_run_id -> latest quote_sub_orders.run_id (non-null)
+  let effectiveRunId = runId || null;
+  if (!effectiveRunId){
+    try {
+      const { data: active } = await supabase
+        .from('quote_submissions')
+        .select('active_run_id')
+        .eq('quote_id', quoteId)
+        .maybeSingle();
+      effectiveRunId = active?.active_run_id || null;
+      if (!effectiveRunId){
+        const { data: latestQso } = await supabase
+          .from('quote_sub_orders')
+          .select('run_id')
+          .eq('quote_id', quoteId)
+          .not('run_id', 'is', null)
+          .order('created_at', { ascending: false })
+          .limit(1);
+        effectiveRunId = Array.isArray(latestQso) && latestQso[0]?.run_id ? latestQso[0].run_id : null;
+      }
+    } catch {}
+  }
+
+  const itemsQuery = supabase
+    .from('quote_sub_orders')
+    .select('id, billable_pages, unit_rate, unit_rate_override, certification_amount, run_id')
+    .eq('quote_id', quoteId);
+  const scopedItemsQuery = effectiveRunId ? itemsQuery.eq('run_id', effectiveRunId) : itemsQuery;
+
   const [ { data: items }, { data: adjustments }, { data: certifications } ] = await Promise.all([
-    supabase
-      .from('quote_sub_orders')
-      .select('id, billable_pages, unit_rate, unit_rate_override, certification_amount')
-      .eq('quote_id', quoteId),
+    scopedItemsQuery,
     supabase
       .from('quote_adjustments')
       .select('id, type, discount_type, discount_value, total_amount')
@@ -70,6 +96,7 @@ export async function recalcAndUpsertUnifiedQuoteResults(quoteId){
 
   const upsert = {
     quote_id: quoteId,
+    run_id: effectiveRunId || null,
     subtotal,
     tax,
     total,
@@ -78,8 +105,8 @@ export async function recalcAndUpsertUnifiedQuoteResults(quoteId){
     results_json: {
       pricing: {
         translation: round2(translation),
-        certification: round2(certification), // kept for backward compatibility
-        certifications: round2(certification), // explicit key for new table usage
+        certification: round2(certification),
+        certifications: round2(certification),
         additional_items: round2(additionalItemsTotal),
         discounts_or_surcharges: round2(discountsAndSurchargesTotal),
         subtotal,
@@ -90,7 +117,9 @@ export async function recalcAndUpsertUnifiedQuoteResults(quoteId){
     }
   };
 
-  const { error } = await supabase.from('quote_results').upsert(upsert, { onConflict: 'quote_id' });
+  // Upsert by (quote_id, run_id) when available; fallback to legacy quote_id-only
+  const conflictTarget = upsert.run_id ? 'quote_id,run_id' : 'quote_id';
+  const { error } = await supabase.from('quote_results').upsert(upsert, { onConflict: conflictTarget });
   if (error) throw error;
 
   return {

--- a/pages/admin/quotes/[id].jsx
+++ b/pages/admin/quotes/[id].jsx
@@ -62,11 +62,18 @@ export default function Page({ initialAdmin }){
   }
 
   async function addAdjustment(payload){
-    console.log('Admin Quote addAdjustment payload', payload);
-    const resp = await fetch(`/api/admin/quotes/${quote.id}/adjustments`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
-    const json = await resp.json();
-    console.log('Admin Quote addAdjustment response', { ok: resp.ok, status: resp.status, json });
-    if (json?.success){ setAdjustments(a => [...a, json.adjustment]); setTotals(json.totals || totals); }
+    try {
+      console.log('Admin Quote addAdjustment payload', payload);
+      const resp = await fetch(`/api/admin/quotes/${quote.id}/adjustments`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
+      let json = null;
+      try { json = await resp.json(); } catch { json = { error: 'Invalid response' }; }
+      console.log('Admin Quote addAdjustment response', { ok: resp.ok, status: resp.status, json });
+      if (!resp.ok || !json?.success){ throw new Error(json?.error || `Request failed (${resp.status})`); }
+      setAdjustments(a => [...a, json.adjustment]); setTotals(json.totals || totals);
+    } catch (e) {
+      console.error('Failed to add adjustment', e);
+      alert(`Failed to add adjustment: ${e.message}`);
+    }
   }
 
   async function deleteAdjustment(id){

--- a/pages/api/admin/quotes/[quoteId]/analysis-results.js
+++ b/pages/api/admin/quotes/[quoteId]/analysis-results.js
@@ -20,7 +20,7 @@ async function handler(req, res){
     await supabase.from('quote_sub_orders').delete().eq('quote_id', quoteId).eq('run_id', runId);
   }
 
-  const totals = await recalcAndUpsertUnifiedQuoteResults(quoteId);
+  const totals = await recalcAndUpsertUnifiedQuoteResults(quoteId, runId);
   await logAdminActivity({ action: 'analysis_results_cleared', actor_id: req.admin?.id || null, target_id: quoteId, details: { run_id: runId || null } });
   return res.status(200).json({ success: true, totals });
 }

--- a/pages/api/admin/quotes/[quoteId]/line-items.js
+++ b/pages/api/admin/quotes/[quoteId]/line-items.js
@@ -38,10 +38,10 @@ async function handler(req, res){
     .update({ last_edited_by: req.admin?.id || null, last_edited_at: new Date().toISOString() })
     .eq('quote_id', quoteId);
 
-  const totals = await recalcAndUpsertUnifiedQuoteResults(quoteId);
+  const { data: updated } = await supabase.from('quote_sub_orders').select('*').eq('id', line_item_id).maybeSingle();
+  const totals = await recalcAndUpsertUnifiedQuoteResults(quoteId, updated?.run_id || null);
   await logActivity({ adminUserId: req.admin?.id, actionType: 'quote_line_item_updated', targetType: 'quote', targetId: quoteId, details: { line_item_id, updates: patch } });
 
-  const { data: updated } = await supabase.from('quote_sub_orders').select('*').eq('id', line_item_id).maybeSingle();
   return res.status(200).json({ success: true, line_item: updated, totals });
 }
 

--- a/pages/api/admin/quotes/[quoteId]/line-items/from-analysis.js
+++ b/pages/api/admin/quotes/[quoteId]/line-items/from-analysis.js
@@ -205,7 +205,7 @@ async function handler(req, res){
     await supabase.from('quote_submissions').update({ active_run_id: runId }).eq('quote_id', quoteId);
   }
 
-  const totals = await recalcAndUpsertUnifiedQuoteResults(quoteId);
+  const totals = await recalcAndUpsertUnifiedQuoteResults(quoteId, runId);
   await logAdminActivity({ action: 'quote_line_items_from_analysis', actor_id: req.admin?.id || null, target_id: quoteId, details: { count: created?.length || 0, source, run_id: runId || null } });
   return res.status(200).json({ success: true, created: created || [], totals, run_id: runId || null });
 }


### PR DESCRIPTION
## Changes Made

### Core Function Updates
- **Modified `recalcAndUpsertUnifiedQuoteResults()`** to accept optional `runId` parameter
- **Added run ID resolution logic** that determines effective run ID when not provided:
  - First checks `active_run_id` from quote submissions
  - Falls back to latest non-null `run_id` from quote sub orders
- **Updated database queries** to scope items by run ID when available
- **Modified upsert logic** to use composite key `(quote_id, run_id)` when run ID exists, otherwise falls back to legacy `quote_id` only

### API Endpoint Updates
- **Updated analysis results endpoint** to pass run ID to totals calculation
- **Modified line items endpoint** to extract and pass run ID from updated item
- **Updated from-analysis endpoint** to pass run ID to totals calculation
- **Enhanced quote details endpoint** with improved run ID scoping and results fetching

### Frontend Improvements
- **Added error handling** to adjustment creation with try-catch blocks
- **Improved error messaging** with user-friendly alerts for failed operations
- **Enhanced response parsing** with fallback for invalid JSON responses

### Database Schema Changes
- **Added `run_id` field** to quote results upsert operations
- **Implemented composite conflict resolution** for quote results table
- **Enhanced query scoping** to filter by effective run ID across multiple endpoints

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 76`

🔗 [Edit in Builder.io](https://builder.io/app/projects/89e37d52885f4fd0b72eb3f3b05ca6e4/nova-sanctuary)

👀 [Preview Link](https://89e37d52885f4fd0b72eb3f3b05ca6e4-nova-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>89e37d52885f4fd0b72eb3f3b05ca6e4</projectId>-->
<!--<branchName>nova-sanctuary</branchName>-->