### PR TITLE
Fix null initial prop handling in admin forms

### DIFF
--- a/components/admin/AdminForm.jsx
+++ b/components/admin/AdminForm.jsx
@@ -11,16 +11,16 @@ const ROLE_OPTIONS = [
 
 function classNames(...c){ return c.filter(Boolean).join(' '); }
 
-export default function AdminForm({ mode = 'create', initial = null, disableRole = false, disableActive = false, onSubmit, submitting = false }){
-  const [fullName, setFullName] = useState(initial.full_name || '');
-  const [email, setEmail] = useState(initial.email || '');
-  const [role, setRole] = useState(initial.role || 'manager');
-  const [isActive, setIsActive] = useState(initial.is_active !== false);
+export default function AdminForm({ mode = 'create', initial = {}, disableRole = false, disableActive = false, onSubmit, submitting = false }){
+  const [fullName, setFullName] = useState(initial?.full_name || '');
+  const [email, setEmail] = useState(initial?.email || '');
+  const [role, setRole] = useState(initial?.role || 'manager');
+  const [isActive, setIsActive] = useState(initial?.is_active !== false);
   const [errors, setErrors] = useState({});
   const [emailExists, setEmailExists] = useState(false);
   const [checkingEmail, setCheckingEmail] = useState(false);
 
-  useEffect(() => { if (!initial) return; setFullName(initial.full_name || ''); setEmail(initial.email || ''); setRole(initial.role || 'manager'); setIsActive(initial.is_active !== false); setErrors({}); setEmailExists(false); }, [initial]);
+  useEffect(() => { if (!initial || Object.keys(initial).length === 0) return; setFullName(initial.full_name || ''); setEmail(initial.email || ''); setRole(initial.role || 'manager'); setIsActive(initial.is_active !== false); setErrors({}); setEmailExists(false); }, [initial]);
 
   useEffect(() => {
     if (mode !== 'create') return; // only live-check for create

--- a/components/admin/UserForm.jsx
+++ b/components/admin/UserForm.jsx
@@ -9,22 +9,22 @@ const ORDERING_OPTIONS = [
   { value: 'business', label: 'Company/Business' }
 ];
 
-export default function UserForm({ mode = 'create', initial = null, onSubmit, submitting = false }){
-  const [fullName, setFullName] = useState(initial.full_name || '');
-  const [email, setEmail] = useState(initial.email || '');
-  const [phone, setPhone] = useState(initial.phone || ''); // E.164 or ''
-  const [orderingType, setOrderingType] = useState(initial.ordering_type || '');
-  const [companyName, setCompanyName] = useState(initial.company_name || '');
-  const [designation, setDesignation] = useState(initial.designation || '');
-  const [frequency, setFrequency] = useState(initial.frequency || '');
-  const [notes, setNotes] = useState(initial.notes || '');
-  const [tags, setTags] = useState(Array.isArray(initial.tags) ? initial.tags.join(', ') : '');
+export default function UserForm({ mode = 'create', initial = {}, onSubmit, submitting = false }){
+  const [fullName, setFullName] = useState(initial?.full_name || '');
+  const [email, setEmail] = useState(initial?.email || '');
+  const [phone, setPhone] = useState(initial?.phone || ''); // E.164 or ''
+  const [orderingType, setOrderingType] = useState(initial?.ordering_type || '');
+  const [companyName, setCompanyName] = useState(initial?.company_name || '');
+  const [designation, setDesignation] = useState(initial?.designation || '');
+  const [frequency, setFrequency] = useState(initial?.frequency || '');
+  const [notes, setNotes] = useState(initial?.notes || '');
+  const [tags, setTags] = useState(Array.isArray(initial?.tags) ? initial.tags.join(', ') : '');
   const [errors, setErrors] = useState({});
   const [emailExists, setEmailExists] = useState(false);
   const [checkingEmail, setCheckingEmail] = useState(false);
 
   useEffect(() => {
-    if (!initial) return;
+    if (!initial || Object.keys(initial).length === 0) return;
     setFullName(initial.full_name || '');
     setEmail(initial.email || '');
     setPhone(initial.phone || '');


### PR DESCRIPTION
## Purpose

The user encountered a 500 Internal Server Error when accessing the admin users page, likely caused by null reference errors when the `initial` prop was null or undefined in the admin forms.

## Code changes

- Changed default value of `initial` prop from `null` to `{}` in both `AdminForm` and `UserForm` components
- Added optional chaining (`?.`) to all property accesses on the `initial` object to prevent null reference errors
- Updated the useEffect condition to check for empty objects in addition to null/undefined values
- These changes ensure the forms handle missing or null initial data gracefully without throwing runtime errors

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 90`

🔗 [Edit in Builder.io](https://builder.io/app/projects/89e37d52885f4fd0b72eb3f3b05ca6e4/vortex-verse)

👀 [Preview Link](https://89e37d52885f4fd0b72eb3f3b05ca6e4-vortex-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>89e37d52885f4fd0b72eb3f3b05ca6e4</projectId>-->
<!--<branchName>vortex-verse</branchName>-->