### PR TITLE
Add create quote functionality to admin panel

### DIFF
--- a/pages/admin/quotes.jsx
+++ b/pages/admin/quotes.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import AdminLayout from '../../components/admin/AdminLayout';
 import { getServerSideAdminWithPermission } from '../../lib/withAdminPage';
+import { canCreateQuote } from '../../lib/permissions';
 
 export const getServerSideProps = getServerSideAdminWithPermission('quotes','view');
 
@@ -29,12 +30,69 @@ function StatusBadge({ state }){
   return <span className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-semibold ${color}`}>{state||'draft'}</span>;
 }
 
+function CreateQuoteModal({ open, onClose }){
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [source, setSource] = useState('');
+  const [target, setTarget] = useState('');
+  const [intendedUse, setIntendedUse] = useState('');
+  const [saving, setSaving] = useState(false);
+  async function submit(e){
+    e.preventDefault(); if (saving) return; setSaving(true);
+    try {
+      const resp = await fetch('/api/admin/quotes', { method:'POST', headers:{ 'Content-Type':'application/json' }, body: JSON.stringify({ name, email, source_lang: source, target_lang: target, intended_use: intendedUse }) });
+      const json = await resp.json();
+      if (!resp.ok || !json?.success) throw new Error(json?.error || `Request failed (${resp.status})`);
+      window.location.href = `/admin/quotes/${json.quote_id}`;
+    } catch (e) {
+      alert(e.message || 'Failed to create quote');
+    } finally { setSaving(false); }
+  }
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div className="w-full max-w-lg rounded bg-white p-4">
+        <div className="mb-3 text-lg font-semibold">Create New Quote</div>
+        <form onSubmit={submit} className="space-y-3">
+          <div>
+            <label className="block text-sm font-medium mb-1">Customer Name</label>
+            <input value={name} onChange={e=> setName(e.target.value)} className="w-full rounded border px-3 py-2" required />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Customer Email</label>
+            <input type="email" value={email} onChange={e=> setEmail(e.target.value)} className="w-full rounded border px-3 py-2" required />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-sm font-medium mb-1">Source Language</label>
+              <input value={source} onChange={e=> setSource(e.target.value)} className="w-full rounded border px-3 py-2" />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Target Language</label>
+              <input value={target} onChange={e=> setTarget(e.target.value)} className="w-full rounded border px-3 py-2" />
+            </div>
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Intended Use (optional)</label>
+            <input value={intendedUse} onChange={e=> setIntendedUse(e.target.value)} className="w-full rounded border px-3 py-2" />
+          </div>
+          <div className="flex gap-2 pt-2">
+            <button type="submit" disabled={saving} className="rounded bg-cyan-600 px-3 py-2 text-white disabled:opacity-50">Create</button>
+            <button type="button" onClick={onClose} className="rounded border px-3 py-2">Cancel</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
 export default function Page({ initialAdmin }){
   const [status, setStatus] = useState('all');
   const [search, setSearch] = useState('');
   const [page, setPage] = useState(1);
   const [loading, setLoading] = useState(false);
   const [data, setData] = useState({ quotes: [], total_count: 0, pages: 1, page: 1 });
+  const [showCreate, setShowCreate] = useState(false);
 
   useEffect(() => {
     const t = setTimeout(() => {
@@ -52,6 +110,8 @@ export default function Page({ initialAdmin }){
     return () => clearTimeout(t);
   }, [status, search, page]);
 
+  const allowCreate = canCreateQuote(initialAdmin?.role);
+
   return (
     <AdminLayout title="All Quotes" initialAdmin={initialAdmin}>
       <div className="rounded-lg bg-white p-4 ring-1 ring-gray-100">
@@ -61,8 +121,11 @@ export default function Page({ initialAdmin }){
               <button key={s.key} onClick={() => { setStatus(s.key); setPage(1); }} className={`rounded-md border px-3 py-1 text-sm ${status===s.key? 'bg-cyan-600 text-white border-cyan-600' : 'bg-white text-gray-700 border-gray-200 hover:bg-gray-50'}`}>{s.label}</button>
             ))}
           </div>
-          <div>
+          <div className="flex items-center gap-2">
             <input value={search} onChange={e=>{ setSearch(e.target.value); setPage(1); }} className="w-64 rounded-md border border-gray-300 px-3 py-2 text-sm" placeholder="Search order #, name, email" />
+            {allowCreate && (
+              <button onClick={()=> setShowCreate(true)} className="rounded bg-cyan-600 text-white px-3 py-2 text-sm">+ New Quote</button>
+            )}
           </div>
         </div>
 
@@ -101,6 +164,7 @@ export default function Page({ initialAdmin }){
           <button className="rounded border px-3 py-1 text-sm disabled:opacity-50" onClick={()=> setPage(p=> Math.min((data.pages||1), p+1))} disabled={page>=(data.pages||1)}>Next</button>
         </div>
       </div>
+      <CreateQuoteModal open={showCreate} onClose={()=> setShowCreate(false)} />
     </AdminLayout>
   );
 }


### PR DESCRIPTION
## Purpose

This PR implements the ability to create new quotes directly from the admin panel. The user requested functionality specifically for the admin panel quotes section to allow creating new quotes, with no changes to the user dashboard or order flow.

## Code changes

- **Frontend (quotes.jsx)**: Added a "New Quote" button and modal dialog for creating quotes with form fields for customer name, email, source/target languages, and intended use
- **Backend (quotes/index.js)**: Extended the API endpoint to handle POST requests for quote creation with validation, quote number generation, and activity logging
- **Permissions**: Integrated permission checking using `canCreateQuote()` to control access to the create functionality
- **Form handling**: Implemented form submission with error handling and automatic redirect to the newly created quote page

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 92`

🔗 [Edit in Builder.io](https://builder.io/app/projects/89e37d52885f4fd0b72eb3f3b05ca6e4/pulse-garden)

👀 [Preview Link](https://89e37d52885f4fd0b72eb3f3b05ca6e4-pulse-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>89e37d52885f4fd0b72eb3f3b05ca6e4</projectId>-->
<!--<branchName>pulse-garden</branchName>-->