### PR TITLE
Add customer messaging with order number in admin notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.next/
+node_modules/

--- a/components/dashboard/CustomerMessages.jsx
+++ b/components/dashboard/CustomerMessages.jsx
@@ -1,0 +1,135 @@
+import { useState, useEffect, useRef } from 'react';
+
+export default function CustomerMessages({ orderId }) {
+  const [messages, setMessages] = useState([]);
+  const [text, setText] = useState('');
+  const [sending, setSending] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const bottomRef = useRef(null);
+
+  const fetchMessages = async () => {
+    try {
+      const res = await fetch(`/api/dashboard/orders/${orderId}/messages`);
+      if (!res.ok) throw new Error('Failed to load messages');
+      const data = await res.json();
+      setMessages(data.messages || []);
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (orderId) {
+      fetchMessages();
+      const interval = setInterval(fetchMessages, 30000);
+      return () => clearInterval(interval);
+    }
+  }, [orderId]);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  const handleSend = async (e) => {
+    e.preventDefault();
+    if (!text.trim() || sending) return;
+
+    setSending(true);
+    setError('');
+    try {
+      const res = await fetch(`/api/dashboard/orders/${orderId}/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: text.trim() }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || 'Failed to send message');
+      }
+      const data = await res.json();
+      setMessages(prev => [...prev, data.message]);
+      setText('');
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const formatTime = (d) => {
+    try {
+      return new Date(d).toLocaleString('en-US', {
+        month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit',
+      });
+    } catch { return ''; }
+  };
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-6">
+      <h3 className="text-lg font-semibold text-gray-900 mb-4">Messages</h3>
+
+      {loading ? (
+        <div className="flex justify-center py-6">
+          <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-cyan-500"></div>
+        </div>
+      ) : (
+        <>
+          {messages.length === 0 ? (
+            <p className="text-gray-500 text-sm mb-4">No messages yet. Send a message to our team below.</p>
+          ) : (
+            <div className="space-y-3 mb-4 max-h-96 overflow-y-auto pr-1">
+              {messages.map((m) => (
+                <div
+                  key={m.id}
+                  className={`flex ${m.from_customer ? 'justify-end' : 'justify-start'}`}
+                >
+                  <div
+                    className={`max-w-[80%] rounded-lg px-4 py-2 text-sm ${
+                      m.from_customer
+                        ? 'bg-cyan-500 text-white'
+                        : 'bg-gray-100 text-gray-900'
+                    }`}
+                  >
+                    {!m.from_customer && (
+                      <div className="text-xs font-medium text-cyan-700 mb-1">Cethos Team</div>
+                    )}
+                    <div className="whitespace-pre-wrap">{m.text}</div>
+                    <div className={`text-xs mt-1 ${m.from_customer ? 'text-cyan-100' : 'text-gray-400'}`}>
+                      {formatTime(m.created_at)}
+                    </div>
+                  </div>
+                </div>
+              ))}
+              <div ref={bottomRef} />
+            </div>
+          )}
+
+          {error && (
+            <div className="text-red-600 text-sm mb-2">{error}</div>
+          )}
+
+          <form onSubmit={handleSend} className="flex gap-2">
+            <input
+              type="text"
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              placeholder="Type a message..."
+              maxLength={5000}
+              className="flex-1 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-transparent"
+            />
+            <button
+              type="submit"
+              disabled={!text.trim() || sending}
+              className="bg-cyan-500 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-cyan-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              {sending ? 'Sending...' : 'Send'}
+            </button>
+          </form>
+        </>
+      )}
+    </div>
+  );
+}

--- a/lib/email.js
+++ b/lib/email.js
@@ -378,6 +378,54 @@ export async function sendHitlRequestInfoEmail({ email, first_name, quote_number
   const resp = await apiInstance.sendTransacEmail(sendSmtpEmail); const messageId = resp?.messageId || resp?.response?.body?.messageId || null; await logEmailSent({ email_type:'hitl_request_info', recipient: email, provider_id: messageId, status:'sent' }); return { success:true, messageId };
 }
 
+export async function sendNewCustomerMessageEmail({ orderNumber, orderId, customerName, customerEmail, messageText }) {
+  const ADMIN_EMAIL = process.env.ADMIN_NOTIFICATION_EMAIL || process.env.BREVO_FROM_EMAIL || FROM_EMAIL;
+  if (!ADMIN_EMAIL) return { success: false, error: new Error('Missing admin email') };
+
+  const subject = `New Customer Message – Order #${simpleEscape(orderNumber || 'N/A')}`;
+  const adminUrl = `${SITE_URL}/admin/orders/${orderId}`;
+  const html = `<!DOCTYPE html>
+<html><body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial; background:#f6f9fc;">
+  <div style="max-width:640px;margin:0 auto;padding:24px;">
+    <div style="background:#fff;border-radius:10px;padding:28px;border:1px solid #e6ecf1;">
+      <h1 style="margin:0 0 16px 0;color:#111;">New Customer Message</h1>
+      <div style="background:#f8f9fa;border-radius:6px;padding:16px;margin:0 0 16px 0;">
+        <div style="display:flex;justify-content:space-between;padding:6px 0;border-bottom:1px solid #eee;">
+          <span style="font-weight:600;color:#495057;">Order Number:</span>
+          <span>${simpleEscape(orderNumber || 'N/A')}</span>
+        </div>
+        <div style="display:flex;justify-content:space-between;padding:6px 0;">
+          <span style="font-weight:600;color:#495057;">From:</span>
+          <span>${simpleEscape(customerName)}${customerEmail ? ` (${simpleEscape(customerEmail)})` : ''}</span>
+        </div>
+      </div>
+      <p style="font-weight:600;color:#495057;margin:0 0 4px 0;">Message:</p>
+      <div style="background:#f8f9fa;border-radius:6px;padding:16px;margin:0 0 20px 0;white-space:pre-wrap;">${simpleEscape(messageText)}</div>
+      <div style="text-align:center;margin:16px 0;">
+        <a href="${adminUrl}" style="display:inline-block;background:#2563eb;color:#fff;text-decoration:none;padding:12px 20px;border-radius:6px;font-weight:600;">View in Admin Panel</a>
+      </div>
+      <p style="color:#6b7280;font-size:13px;text-align:center;margin-top:16px;">© ${new Date().getFullYear()} ${simpleEscape(FROM_NAME)}</p>
+    </div>
+  </div>
+</body></html>`;
+
+  try {
+    const sendSmtpEmail = new brevo.SendSmtpEmail();
+    sendSmtpEmail.subject = subject;
+    sendSmtpEmail.to = [{ email: ADMIN_EMAIL, name: 'Cethos Support' }];
+    sendSmtpEmail.sender = { email: FROM_EMAIL, name: 'CETHOS Customer Portal' };
+    sendSmtpEmail.htmlContent = html;
+    sendSmtpEmail.tags = ['customer-message', 'notification'];
+    const resp = await apiInstance.sendTransacEmail(sendSmtpEmail);
+    const messageId = resp?.messageId || resp?.response?.body?.messageId || null;
+    await logEmailSent({ order_id: orderId, email_type: 'customer_message_notification', recipient: ADMIN_EMAIL, provider_id: messageId, status: 'sent' });
+    return { success: true, messageId };
+  } catch (error) {
+    await logEmailSent({ order_id: orderId, email_type: 'customer_message_notification', recipient: ADMIN_EMAIL, status: 'failed', error_message: error.message });
+    return { success: false, error };
+  }
+}
+
 export async function sendHitlRejectedEmail({ email, first_name, quote_number, reason, message }) {
   if (!email) return { success: false, error: new Error('Missing recipient email') };
   const subject = `Quote Update - Quote #${simpleEscape(quote_number||'')}`;

--- a/pages/api/dashboard/orders/[id]/messages.js
+++ b/pages/api/dashboard/orders/[id]/messages.js
@@ -1,0 +1,116 @@
+import { withApiBreadcrumbs } from '../../../../../lib/sentry';
+import { getSupabaseServerClient } from '../../../../../lib/supabaseServer';
+import { sendNewCustomerMessageEmail } from '../../../../../lib/email';
+
+function parseCookies(cookieHeader) {
+  const out = {};
+  if (!cookieHeader) return out;
+  const parts = cookieHeader.split(';');
+  for (const p of parts) {
+    const [k, ...v] = p.trim().split('=');
+    out[k] = decodeURIComponent(v.join('='));
+  }
+  return out;
+}
+
+async function getAuthedUser(req) {
+  const cookies = parseCookies(req.headers.cookie || '');
+  const token = cookies['session_token'];
+  if (!token) return { status: 401, error: 'Unauthorized' };
+  const supabase = getSupabaseServerClient();
+  const nowIso = new Date().toISOString();
+  const { data: session } = await supabase
+    .from('user_sessions')
+    .select('*')
+    .eq('session_token', token)
+    .gt('expires_at', nowIso)
+    .maybeSingle();
+  if (!session || session.user_type !== 'customer') return { status: 401, error: 'Invalid session' };
+  return { supabase, userId: session.user_id };
+}
+
+async function handler(req, res) {
+  try {
+    const auth = await getAuthedUser(req);
+    if (auth.status) return res.status(auth.status).json({ error: auth.error });
+    const { supabase, userId } = auth;
+
+    const { id: orderId } = req.query;
+
+    // Verify the order belongs to this customer
+    const { data: order } = await supabase
+      .from('orders')
+      .select('id, order_number, user_id, customer_email')
+      .eq('id', orderId)
+      .maybeSingle();
+
+    if (!order) return res.status(404).json({ error: 'Order not found' });
+    if (order.user_id !== userId) return res.status(403).json({ error: 'Forbidden' });
+
+    if (req.method === 'GET') {
+      const { data: messages, error } = await supabase
+        .from('order_messages')
+        .select('*')
+        .eq('order_id', orderId)
+        .eq('is_internal', false)
+        .order('created_at', { ascending: true });
+
+      if (error) throw error;
+      return res.status(200).json({ messages: messages || [] });
+
+    } else if (req.method === 'POST') {
+      const { text } = req.body;
+
+      if (!text || !text.trim()) {
+        return res.status(400).json({ error: 'Message text is required' });
+      }
+
+      const { data: message, error } = await supabase
+        .from('order_messages')
+        .insert([{
+          order_id: orderId,
+          text: text.trim(),
+          from_customer: true,
+          is_internal: false,
+          read: false,
+          created_at: new Date().toISOString(),
+        }])
+        .select()
+        .single();
+
+      if (error) throw error;
+
+      // Look up customer name for the email notification
+      const { data: customer } = await supabase
+        .from('users')
+        .select('first_name, last_name, email')
+        .eq('id', userId)
+        .maybeSingle();
+
+      const customerName = customer
+        ? [customer.first_name, customer.last_name].filter(Boolean).join(' ') || customer.email
+        : order.customer_email || 'Customer';
+      const customerEmail = customer?.email || order.customer_email || '';
+
+      // Send admin notification email (non-blocking)
+      sendNewCustomerMessageEmail({
+        orderNumber: order.order_number,
+        orderId: order.id,
+        customerName,
+        customerEmail,
+        messageText: text.trim(),
+      }).catch(err => console.error('Failed to send admin notification:', err));
+
+      return res.status(201).json({ message });
+
+    } else {
+      res.setHeader('Allow', ['GET', 'POST']);
+      return res.status(405).json({ error: 'Method Not Allowed' });
+    }
+  } catch (err) {
+    console.error('Customer messages API error:', err);
+    return res.status(500).json({ error: err.message || 'Unexpected error' });
+  }
+}
+
+export default withApiBreadcrumbs(handler);

--- a/pages/dashboard/orders/[id].js
+++ b/pages/dashboard/orders/[id].js
@@ -3,6 +3,7 @@ import DashboardLayout from '../../../components/DashboardLayout';
 import { useAuth } from '../../../middleware/auth';
 import StatusBadge from '../../../components/dashboard/StatusBadge';
 import FilesDisplay from '../../../components/FilesDisplay';
+import CustomerMessages from '../../../components/dashboard/CustomerMessages';
 import Link from 'next/link';
 import { formatForDisplay as formatPhone } from '../../../lib/formatters/phone';
 
@@ -87,6 +88,8 @@ export default function OrderDetailPage(){
               isAdmin={false}
             />
           </div>
+
+          <CustomerMessages orderId={o.id} />
 
           {(o.billing_address || o.shipping_address) && (
             <div className="bg-white rounded-lg border border-gray-200 p-6">


### PR DESCRIPTION
- Add customer-facing message API endpoint at /api/dashboard/orders/[id]/messages
  (GET to fetch messages, POST to send with auth verification)
- Add sendNewCustomerMessageEmail() to lib/email.js that sends admin notification
  with order number, customer name/email, message text, and "View in Admin Panel" link
- Add CustomerMessages component to customer order detail page with real-time chat UI
- Email sender shows as "CETHOS Customer Portal" matching existing notification pattern

https://claude.ai/code/session_011zntt7zHPfHepFWofVBwh8