### PR TITLE
security: stop hardcoding Supabase service_role key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 .next/
 node_modules/
+
+# local env files (never commit)
+.env
+.env.*
+!.env.example

--- a/code/scripts/check-order.js
+++ b/code/scripts/check-order.js
@@ -1,7 +1,10 @@
 const { createClient } = require('@supabase/supabase-js');
 
-const supabaseUrl = 'https://ogxklbdjffbhtlabwonl.supabase.co';
-const supabaseServiceKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im9neGtsYmRqZmZiaHRsYWJ3b25sIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc1ODcyOTk4NSwiZXhwIjoyMDc0MzA1OTg1fQ.0r8xrof4SFQ8VzNa-ipR1-_3qXJ6L7m2Py_DGEhdDHI';
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SECRET_KEY;
+if (!supabaseUrl || !supabaseServiceKey) {
+  throw new Error('Missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY env vars');
+}
 
 const supabase = createClient(supabaseUrl, supabaseServiceKey);
 

--- a/code/scripts/query-order-details.js
+++ b/code/scripts/query-order-details.js
@@ -1,7 +1,10 @@
 const { createClient } = require('@supabase/supabase-js');
 
-const supabaseUrl = 'https://ogxklbdjffbhtlabwonl.supabase.co';
-const supabaseServiceKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im9neGtsYmRqZmZiaHRsYWJ3b25sIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc1ODcyOTk4NSwiZXhwIjoyMDc0MzA1OTg1fQ.0r8xrof4SFQ8VzNa-ipR1-_3qXJ6L7m2Py_DGEhdDHI';
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SECRET_KEY;
+if (!supabaseUrl || !supabaseServiceKey) {
+  throw new Error('Missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY env vars');
+}
 
 const supabase = createClient(supabaseUrl, supabaseServiceKey);
 

--- a/lib/supabaseServer.js
+++ b/lib/supabaseServer.js
@@ -12,8 +12,10 @@ function resolveKey() {
   const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
     || process.env.SUPABASE_SERVICE_KEY
     || process.env.SUPABASE_SECRET_KEY;
-  if (serviceKey) return serviceKey;
-  return process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  // No anon fallback: the server client must use the secret/service key.
+  // Returning undefined here makes getSupabaseServerClient() throw loudly
+  // instead of silently running with reduced (anon) privileges.
+  return serviceKey;
 }
 
 export function getSupabaseServerClient() {

--- a/scripts/check-order.js
+++ b/scripts/check-order.js
@@ -1,7 +1,10 @@
 const { createClient } = require('@supabase/supabase-js');
 
-const supabaseUrl = 'https://ogxklbdjffbhtlabwonl.supabase.co';
-const supabaseServiceKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im9neGtsYmRqZmZiaHRsYWJ3b25sIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc1ODcyOTk4NSwiZXhwIjoyMDc0MzA1OTg1fQ.0r8xrof4SFQ8VzNa-ipR1-_3qXJ6L7m2Py_DGEhdDHI';
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SECRET_KEY;
+if (!supabaseUrl || !supabaseServiceKey) {
+  throw new Error('Missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY env vars');
+}
 
 const supabase = createClient(supabaseUrl, supabaseServiceKey);
 


### PR DESCRIPTION
Scripts and the server client now read Supabase credentials from environment variables instead of an inline service_role JWT (that key was already revoked by disabling legacy keys on the SwornNow project). The server client no longer silently falls back to the anon key when the secret is missing — it now fails loudly. Also ignore .env files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)